### PR TITLE
support-lambda-url-transformation

### DIFF
--- a/src/apiGatewayTransformers.js
+++ b/src/apiGatewayTransformers.js
@@ -2,7 +2,7 @@ const URL = require('url')
 
 const getURL = (event) => {
   const url = {
-    pathname: event.path || '/',
+    pathname: event.path || (event.requestContext && event.requestContext.http && event.requestContext.http.path) || '/',
     query: event.multiValueQueryStringParameters || event.queryStringParameters
   }
   return URL.format(url)
@@ -17,6 +17,8 @@ const getPayload = (event) => {
     return Buffer.from(event.body, event.isBase64Encoded ? 'base64' : 'utf8')
   } else if (type === 'object') {
     return Buffer.from(JSON.stringify(event.body))
+  } else if(type === 'undefined') {
+    return Buffer.from(JSON.stringify(null))
   }
 
   throw new Error(`Unexpected event.body type: "${type}"`)
@@ -55,7 +57,7 @@ const isBinary = (headers) => {
 
 const transformRequest = (event) => {
   return {
-    method: event.httpMethod,
+    method: event.httpMethod || event.requestContext.http.method,
     url: getURL(event),
     payload: getPayload(event),
     headers: getHeaders(event),


### PR DESCRIPTION
Addded support for lambda-url which is slightly different than the regular api-gateway proxy lambda integration